### PR TITLE
Add support for site maintenance pages and config

### DIFF
--- a/accuconf/static/accuconf.css
+++ b/accuconf/static/accuconf.css
@@ -67,3 +67,13 @@ body {
     color: grey;
 }
 
+.inconvenience {
+    font-family: sans-serif;
+    font-weight: bold;
+    color: 6666ff;
+    left: 50%;
+    position: fixed;
+    height: 10px;
+    width: 400px;
+    margin-left: -200px;
+}

--- a/accuconf/templates/maintenance.html
+++ b/accuconf/templates/maintenance.html
@@ -1,0 +1,33 @@
+<html lang="en">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    {% block head %}
+      <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+      <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-min.css">
+      <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='accuconf.css') }}">
+      <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+      <title>{% block title%} {% endblock %} - ACCUConf</title>
+    {% endblock %}
+  </head>
+  <body>
+    <div  id="main">
+      <div class="banner">
+        <div class="pure-g">
+          <div class="pure-u-1">
+            <img src="static/logo.png" alt="logo"/>
+          </div>
+        </div>
+      </div>
+      <div class="content">
+        <div class="pure-g">
+          <div class="pure-u-1">
+            <div class="inconvenience">
+                <p> This site is undergoing maintenance at the moment. We sincerely regret the inconvenience caused. We will be back online shorty </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+

--- a/accuconf/views.py
+++ b/accuconf/views.py
@@ -7,6 +7,8 @@ from flask import render_template, flash, redirect, url_for
 
 @app.route("/")
 def index():
+    if app.config.get("MAINTENANCE"):
+        return redirect(url_for("maintenance"))
     when_where = ""
     committee = ""
     venuefile = app.config.get('VENUE')
@@ -25,3 +27,8 @@ def index():
         "committee": committee.get("members")
     }
     return render_template("index.html", frontpage=frontpage)
+
+
+@app.route("/maintenance")
+def maintenance():
+    return render_template("maintenance.html")

--- a/accuconf_config.py
+++ b/accuconf_config.py
@@ -9,15 +9,25 @@ class Config(object):
     DATA_DIR = Path("/etc/accuconf/data")
     VENUE = DATA_DIR / "venue.json"
     COMMITTEE = DATA_DIR / "committee.json"
+    MAINTENANCE = False
 
-class ProductionConfig(object):
+
+class ProductionConfig(Config):
     pass
 
 
-class TestConfig(object):
+class TestConfig(Config):
     SQLALCHEMY_DATABASE_URI = "sqlite:///tmp/accuconf_test.db"
     DEBUG = True
     DATA_DIR = Path("/tmp/data")
     VENUE = DATA_DIR / "venue.json"
     COMMITTEE = DATA_DIR / "committee.json"
     FRONTPAGE = DATA_DIR / "frontpage.adoc"
+
+
+class MaintenanceConfig(Config):
+    MAINTENANCE = True
+
+
+class MaintenanceTest(TestConfig):
+    MAINTENANCE = True


### PR DESCRIPTION
Added a new Config class MaintenanceConfig that subclasses
Config. This sets the config attribute MAINTENANCE to True. The views
check if this is true and if so, redirect to a '/maintenance' url that
displays the maintenance page. A separate template has been added for
this.