### PR TITLE
Initialise committee as a dict

### DIFF
--- a/accuconf/views.py
+++ b/accuconf/views.py
@@ -24,7 +24,7 @@ def index():
         "title": "ACCU Conference 2017",
         "data": "Welcome to ACCU Conf 2017",
         "when_where": when_where,
-        "committee": committee.get("members", None)
+        "committee": committee.get("members", [])
     }
     return render_template("index.html", frontpage=frontpage)
 

--- a/accuconf/views.py
+++ b/accuconf/views.py
@@ -9,8 +9,8 @@ from flask import render_template, flash, redirect, url_for
 def index():
     if app.config.get("MAINTENANCE"):
         return redirect(url_for("maintenance"))
-    when_where = ""
-    committee = ""
+    when_where = {}
+    committee = {}
     venuefile = app.config.get('VENUE')
     committeefile = app.config.get('COMMITTEE')
 
@@ -24,7 +24,7 @@ def index():
         "title": "ACCU Conference 2017",
         "data": "Welcome to ACCU Conf 2017",
         "when_where": when_where,
-        "committee": committee.get("members")
+        "committee": committee.get("members", None)
     }
     return render_template("index.html", frontpage=frontpage)
 


### PR DESCRIPTION
Handle cases where the committee file is missing. This sorts out accessing the "members" key of the "committee" dict in error scenarios